### PR TITLE
Integrate admin payments page with backend services

### DIFF
--- a/src/app/(admin)/admin/payments/page.js
+++ b/src/app/(admin)/admin/payments/page.js
@@ -1,34 +1,170 @@
 // File: src/app/(admin)/admin/payments/page.js
 "use client";
 
-import { useState, useMemo } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import PageHeader from "@/components/shared/page-header";
 import PaymentsTable from "@/components/features/admin/payments-table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { qk } from "@/lib/query-keys";
-import { fetchAdminPayments } from "@/lib/mock-data";
 import { toast } from "@/components/ui/sonner";
+import { adminPaymentsOptions, approveAdminPayment } from "@/lib/queries/admin-payments";
 
 // Payments moderation view for administrators.
 export default function AdminPaymentsPage() {
   const queryClient = useQueryClient();
-  const { data: payments = [] } = useQuery({ queryKey: qk.admin.payments(), queryFn: fetchAdminPayments });
-  const [statusFilter, setStatusFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("pending");
 
-  const filteredPayments = useMemo(() => {
-    if (statusFilter === "all") return payments;
-    return payments.filter((payment) => payment.status.toLowerCase() === statusFilter);
-  }, [payments, statusFilter]);
+  const filters = useMemo(() => {
+    if (!statusFilter || statusFilter === "all") return {};
+    return { status: statusFilter };
+  }, [statusFilter]);
+
+  const {
+    data: paymentsData,
+    isLoading,
+    isError,
+    error,
+    isFetching,
+  } = useQuery(adminPaymentsOptions(filters));
+
+  const payments = useMemo(() => paymentsData?.items ?? [], [paymentsData]);
+  const pagination = paymentsData?.pagination ?? null;
+  const availableStatuses = useMemo(() => paymentsData?.availableStatuses ?? [], [paymentsData]);
+
+  const getErrorMessage = (err, fallback) => {
+    if (!err) return fallback;
+    if (err.body) {
+      if (typeof err.body === "string") return err.body;
+      if (err.body?.message) return err.body.message;
+      if (Array.isArray(err.body?.errors)) {
+        const [first] = err.body.errors;
+        if (first?.message) return first.message;
+      }
+    }
+    return err.message || fallback;
+  };
+
+  const statusOptions = useMemo(() => {
+    const normalized = new Set(["pending"]);
+    availableStatuses.forEach((status) => {
+      if (typeof status === "string" && status.trim()) {
+        normalized.add(status.trim().toLowerCase());
+      }
+    });
+    payments.forEach((payment) => {
+      if (payment?.status) normalized.add(payment.status);
+    });
+    if (filters.status) normalized.add(filters.status);
+    return ["all", ...Array.from(normalized).sort((a, b) => a.localeCompare(b))];
+  }, [availableStatuses, payments, filters.status]);
+
+  useEffect(() => {
+    if (!statusOptions.includes(statusFilter)) {
+      setStatusFilter("all");
+    }
+  }, [statusOptions, statusFilter]);
+
+  const approvePaymentMutation = useMutation({
+    mutationFn: ({ payment }) =>
+      approveAdminPayment({
+        appliedUserId: payment.userId,
+        newPlanId: payment.planId,
+        paymentId: payment.paymentId ?? payment.id,
+      }),
+    onMutate: async ({ payment, filters: activeFilters }) => {
+      const normalizedStatus =
+        activeFilters && typeof activeFilters.status === "string"
+          ? activeFilters.status.trim().toLowerCase()
+          : undefined;
+      const normalizedFilters = normalizedStatus && normalizedStatus !== "all"
+        ? { status: normalizedStatus }
+        : { status: "all" };
+      const key = qk.admin.payments(normalizedFilters);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData(key);
+      queryClient.setQueryData(key, (current) => {
+        if (!current) return current;
+        const items = Array.isArray(current.items) ? current.items : [];
+        const mappedItems = items.map((item) =>
+          item.id === payment.id
+            ? { ...item, status: "approved", statusLabel: "Approved", canApprove: false }
+            : item
+        );
+        const shouldFilterByStatus = normalizedFilters.status && normalizedFilters.status !== "all";
+        const filteredItems = shouldFilterByStatus
+          ? mappedItems.filter((item) => item.status === normalizedFilters.status)
+          : mappedItems;
+        let updatedStatuses = Array.isArray(current.availableStatuses)
+          ? new Set(current.availableStatuses.map((status) => (typeof status === "string" ? status.toLowerCase() : status)))
+          : new Set();
+        mappedItems.forEach((item) => {
+          if (item?.status) {
+            updatedStatuses.add(item.status);
+          }
+        });
+        if (shouldFilterByStatus && !filteredItems.some((item) => item.status === normalizedFilters.status)) {
+          updatedStatuses.delete(normalizedFilters.status);
+        }
+        const pagination = current.pagination
+          ? {
+              ...current.pagination,
+              totalItems:
+                shouldFilterByStatus && current.pagination.totalItems != null
+                  ? Math.max(current.pagination.totalItems - 1, 0)
+                  : current.pagination.totalItems,
+            }
+          : current.pagination;
+        return {
+          ...current,
+          items: filteredItems,
+          availableStatuses: Array.from(updatedStatuses),
+          pagination,
+        };
+      });
+      return { previous, key };
+    },
+    onError: (mutationError, variables, context) => {
+      if (context?.previous && context.key) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+      toast.error(getErrorMessage(mutationError, "Failed to approve payment."));
+    },
+    onSuccess: (data, { payment }) => {
+      const message = data?.message ?? `Payment ${payment.reference} approved.`;
+      toast.success(message);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: qk.admin.payments() });
+    },
+  });
+
+  const approvingId = approvePaymentMutation.isPending
+    ? approvePaymentMutation.variables?.payment?.id ?? null
+    : null;
 
   const handleApprove = (payment) => {
-    queryClient.setQueryData(qk.admin.payments(), (prev = []) =>
-      prev.map((item) => (item.id === payment.id ? { ...item, status: "Approved" } : item))
-    );
-    toast.success(`Payment ${payment.id} approved.`);
+    if (!payment?.userId || !payment?.planId || !(payment?.paymentId ?? payment?.id)) {
+      toast.error("Payment record is missing required identifiers.");
+      return;
+    }
+    approvePaymentMutation.mutate({ payment, filters });
   };
+
+  const formatStatusLabel = (value) => {
+    if (!value || value === "all") return "All";
+    return value
+      .split(/[\s_-]+/)
+      .filter(Boolean)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(" ");
+  };
+
+  const errorMessage = isError ? getErrorMessage(error, "Failed to load payments.") : null;
+  const showPaginationSummary = !isLoading && !errorMessage && pagination?.totalItems != null;
+  const isRefetching = isFetching && !isLoading;
 
   return (
     <div className="space-y-8">
@@ -47,14 +183,36 @@ export default function AdminPaymentsPage() {
               <SelectValue placeholder="All statuses" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">All</SelectItem>
-              <SelectItem value="pending">Pending</SelectItem>
-              <SelectItem value="approved">Approved</SelectItem>
+              {statusOptions.map((status) => (
+                <SelectItem key={status} value={status}>
+                  {formatStatusLabel(status)}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
+          {isRefetching ? (
+            <p className="text-xs text-muted-foreground">Refreshing…</p>
+          ) : null}
         </CardContent>
       </Card>
-      <PaymentsTable payments={filteredPayments} onApprove={handleApprove} />
+      {showPaginationSummary ? (
+        <p className="text-sm text-muted-foreground">
+          Showing {payments.length} {filters.status ? `${formatStatusLabel(filters.status).toLowerCase()} ` : ""}payments
+          {typeof pagination.totalItems === "number" ? ` (of ${pagination.totalItems})` : ""}.
+        </p>
+      ) : null}
+      {errorMessage ? (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+          {errorMessage}
+        </div>
+      ) : (
+        <PaymentsTable
+          payments={payments}
+          isLoading={isLoading}
+          approvingId={approvingId}
+          onApprove={handleApprove}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/features/admin/payments-table.js
+++ b/src/components/features/admin/payments-table.js
@@ -5,8 +5,67 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
+const toTitleCase = (value) => {
+  if (typeof value !== "string" || !value.trim()) return value;
+  return value
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+};
+
+const formatAmount = (amount, currency) => {
+  if (amount == null) return "—";
+  const numericAmount = typeof amount === "number" ? amount : Number(amount);
+  if (!Number.isFinite(numericAmount)) {
+    return currency ? `${amount} ${currency}` : String(amount);
+  }
+  const safeCurrency = currency || "USD";
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency: safeCurrency }).format(numericAmount);
+  } catch {
+    return currency ? `${numericAmount} ${currency}` : String(numericAmount);
+  }
+};
+
+const formatDateTime = (value) => {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  try {
+    return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+  } catch {
+    return date.toLocaleString();
+  }
+};
+
+const badgeVariantForStatus = (status) => {
+  switch (status) {
+    case "approved":
+    case "active":
+    case "success":
+      return "outline";
+    case "pending":
+    case "processing":
+      return "secondary";
+    case "rejected":
+    case "failed":
+    case "declined":
+    case "canceled":
+    case "cancelled":
+    case "refunded":
+      return "destructive";
+    default:
+      return "outline";
+  }
+};
+
 // Displays manual payment submissions awaiting review.
-export default function PaymentsTable({ payments = [], onApprove }) {
+export default function PaymentsTable({ payments = [], isLoading = false, approvingId = null, onApprove }) {
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading payments…</p>;
+  }
+
   if (!payments.length) {
     return <p className="text-sm text-muted-foreground">No payments found.</p>;
   }
@@ -17,7 +76,7 @@ export default function PaymentsTable({ payments = [], onApprove }) {
         <TableHeader>
           <TableRow>
             <TableHead>Reference</TableHead>
-            <TableHead>User</TableHead>
+            <TableHead>Customer</TableHead>
             <TableHead>Amount</TableHead>
             <TableHead>Method</TableHead>
             <TableHead>Status</TableHead>
@@ -26,27 +85,61 @@ export default function PaymentsTable({ payments = [], onApprove }) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {payments.map((payment) => (
-            <TableRow key={payment.id}>
-              <TableCell>{payment.id}</TableCell>
-              <TableCell>{payment.user}</TableCell>
-              <TableCell>${payment.amount}</TableCell>
-              <TableCell>{payment.method}</TableCell>
-              <TableCell>
-                <Badge variant={payment.status === "Approved" ? "outline" : "secondary"}>{payment.status}</Badge>
-              </TableCell>
-              <TableCell>{payment.submittedAt}</TableCell>
-              <TableCell className="text-right">
-                <Button
-                  size="sm"
-                  disabled={payment.status === "Approved"}
-                  onClick={() => onApprove?.(payment)}
-                >
-                  Approve
-                </Button>
-              </TableCell>
-            </TableRow>
-          ))}
+          {payments.map((payment) => {
+            const isApproving = approvingId === payment.id;
+            const statusLabel = payment.statusLabel || toTitleCase(payment.status) || "Unknown";
+            const purposeLabel = payment.purpose ? toTitleCase(payment.purpose) : null;
+            const methodLabel = payment.paymentGateway ? toTitleCase(payment.paymentGateway) : null;
+            const methodDetails = payment.paymentMethodDetails ? toTitleCase(payment.paymentMethodDetails) : null;
+
+            return (
+              <TableRow key={payment.id}>
+                <TableCell>
+                  <div className="font-medium">{payment.reference}</div>
+                  {payment.paymentId && payment.paymentId !== payment.reference ? (
+                    <div className="text-xs text-muted-foreground">{payment.paymentId}</div>
+                  ) : null}
+                  {payment.orderId ? (
+                    <div className="text-xs text-muted-foreground">Order: {payment.orderId}</div>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  <div className="font-medium">{payment.userName || "Unknown user"}</div>
+                  {payment.userEmail ? (
+                    <div className="text-xs text-muted-foreground">{payment.userEmail}</div>
+                  ) : null}
+                  {payment.planName ? (
+                    <div className="text-xs text-muted-foreground">Plan: {payment.planName}</div>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  <div className="font-medium">{formatAmount(payment.amount, payment.currency)}</div>
+                  {purposeLabel ? (
+                    <div className="text-xs text-muted-foreground">{purposeLabel}</div>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  <div className="font-medium">{methodLabel || "—"}</div>
+                  {methodDetails ? (
+                    <div className="text-xs text-muted-foreground">{methodDetails}</div>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={badgeVariantForStatus(payment.status)}>{statusLabel}</Badge>
+                </TableCell>
+                <TableCell>{formatDateTime(payment.submittedAt)}</TableCell>
+                <TableCell className="text-right">
+                  <Button
+                    size="sm"
+                    disabled={!payment.canApprove || isApproving || !onApprove}
+                    onClick={() => onApprove?.(payment)}
+                  >
+                    {isApproving ? "Approving…" : "Approve"}
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </div>

--- a/src/lib/queries/admin-payments.js
+++ b/src/lib/queries/admin-payments.js
@@ -1,0 +1,194 @@
+// lib/queries/admin-payments.js
+import { apiJSON } from "@/lib/api";
+import { qk } from "@/lib/query-keys";
+
+const PAYMENT_ENDPOINT = "/api/plans/payment";
+const APPROVE_ENDPOINT = "/api/plans/approve-plan";
+
+const ensureArray = (value) => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (Array.isArray(value?.data)) return value.data;
+  if (Array.isArray(value?.results)) return value.results;
+  if (Array.isArray(value?.items)) return value.items;
+  if (Array.isArray(value?.payload)) return value.payload;
+  if (Array.isArray(value?.payments)) return value.payments;
+  if (Array.isArray(value?.rows)) return value.rows;
+  if (value?.data) return ensureArray(value.data);
+  if (value?.result) return ensureArray(value.result);
+  if (value?.payload) return ensureArray(value.payload);
+  return [];
+};
+
+const toNumber = (value) => {
+  if (value == null) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (typeof value === "object") {
+    if (value.$numberDecimal != null) return toNumber(value.$numberDecimal);
+    if (value.$numberDouble != null) return toNumber(value.$numberDouble);
+    if (value.$numberInt != null) return toNumber(value.$numberInt);
+    if (value.$numberLong != null) return toNumber(value.$numberLong);
+  }
+  return null;
+};
+
+const extractDate = (value) => {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  if (typeof value === "object") {
+    if (value.$date) return extractDate(value.$date);
+  }
+  return null;
+};
+
+const normalizeStatus = (status) => {
+  if (typeof status !== "string") return { status: null, label: "Unknown" };
+  const normalized = status.trim().toLowerCase();
+  if (!normalized) return { status: null, label: "Unknown" };
+  const parts = normalized
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1));
+  return { status: normalized, label: parts.join(" ") || status };
+};
+
+const extractId = (value) => {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "object") {
+    if (value.$oid) return extractId(value.$oid);
+    if (value._id) return extractId(value._id);
+    if (value.id) return extractId(value.id);
+  }
+  return null;
+};
+
+const sanitizeFilters = (filters = {}) => {
+  if (!filters || typeof filters !== "object") return {};
+  const result = {};
+  if (typeof filters.status === "string") {
+    const trimmed = filters.status.trim().toLowerCase();
+    if (trimmed && trimmed !== "all") {
+      result.status = trimmed;
+    }
+  }
+  return result;
+};
+
+const buildQueryString = (filters) => {
+  const params = new URLSearchParams();
+  Object.entries(filters || {}).forEach(([key, value]) => {
+    if (value == null || value === "") return;
+    params.set(key, String(value));
+  });
+  const query = params.toString();
+  return query ? `?${query}` : "";
+};
+
+const normalizePagination = (pagination) => {
+  if (!pagination) return null;
+  return {
+    currentPage: pagination.currentPage ?? null,
+    totalPages: pagination.totalPages ?? null,
+    totalItems: pagination.totalItems ?? null,
+    itemsPerPage: pagination.itemsPerPage ?? null,
+  };
+};
+
+export const normalizeAdminPayment = (payment) => {
+  if (!payment || typeof payment !== "object") return null;
+
+  const id = extractId(payment) ?? `payment-${Date.now()}`;
+  const userId = extractId(payment.userId);
+  const planId = extractId(payment.planId);
+  const amount = toNumber(payment.amount);
+  const refundedAmount = toNumber(payment.refundedAmount);
+  const { status, label: statusLabel } = normalizeStatus(payment.status);
+
+  const submittedAt = extractDate(payment.createdAt) ?? extractDate(payment.processedAt);
+  const updatedAt = extractDate(payment.updatedAt);
+
+  return {
+    id,
+    paymentId: id,
+    reference: payment.gatewayTransactionId || payment.reference || id,
+    gatewayTransactionId: payment.gatewayTransactionId ?? null,
+    userId,
+    userName: payment.userId?.username ?? payment.userId?.name ?? null,
+    userEmail: payment.userId?.email ?? null,
+    planId,
+    planName: payment.planId?.name ?? null,
+    planSlug: payment.planId?.slug ?? null,
+    amount,
+    currency: payment.currency ?? null,
+    refundedAmount,
+    status,
+    statusLabel,
+    canApprove: status === "pending",
+    paymentGateway: payment.paymentGateway ?? null,
+    paymentMethodDetails: payment.paymentMethodDetails ?? null,
+    purpose: payment.purpose ?? null,
+    orderId: extractId(payment.order) ?? (typeof payment.order === "string" ? payment.order : null),
+    submittedAt,
+    processedAt: extractDate(payment.processedAt),
+    updatedAt,
+    raw: payment,
+  };
+};
+
+export const adminPaymentsOptions = (filters = {}) => {
+  const sanitized = sanitizeFilters(filters);
+  const query = buildQueryString(sanitized);
+  const queryKeyFilters = Object.keys(sanitized).length > 0 ? sanitized : { status: sanitized.status ?? "all" };
+
+  return {
+    queryKey: qk.admin.payments(queryKeyFilters),
+    queryFn: async ({ signal }) => {
+      const response = await apiJSON(`${PAYMENT_ENDPOINT}${query}`, { signal });
+      const rawItems = ensureArray(response?.data ?? response);
+      const items = rawItems.map(normalizeAdminPayment).filter(Boolean);
+      const pagination = normalizePagination(response?.pagination);
+      const statusSet = new Set();
+      items.forEach((item) => {
+        if (item?.status) statusSet.add(item.status);
+      });
+      if (Array.isArray(response?.availableStatuses)) {
+        response.availableStatuses.forEach((item) => {
+          if (typeof item === "string" && item.trim()) {
+            statusSet.add(item.trim().toLowerCase());
+          }
+        });
+      }
+      if (sanitized.status) {
+        statusSet.add(sanitized.status);
+      }
+      return {
+        items,
+        pagination,
+        availableStatuses: Array.from(statusSet),
+        raw: response,
+      };
+    },
+    staleTime: 15_000,
+  };
+};
+
+export const approveAdminPayment = ({ appliedUserId, newPlanId, paymentId }) =>
+  apiJSON(APPROVE_ENDPOINT, {
+    method: "POST",
+    body: {
+      appliedUserId,
+      newPlanId,
+      paymentId,
+    },
+  });

--- a/src/lib/query-keys.js
+++ b/src/lib/query-keys.js
@@ -27,7 +27,24 @@ export const qk = {
   },
   admin: {
     plans: () => ["admin", "plans"],
-    payments: () => ["admin", "payments"],
+    payments: (filters) => {
+      if (!filters || (typeof filters === "object" && Object.keys(filters).length === 0)) {
+        return ["admin", "payments"];
+      }
+      if (typeof filters === "string") {
+        return ["admin", "payments", filters];
+      }
+      if (typeof filters === "object") {
+        const normalized = Object.keys(filters)
+          .sort()
+          .reduce((acc, key) => {
+            acc[key] = filters[key];
+            return acc;
+          }, {});
+        return ["admin", "payments", normalized];
+      }
+      return ["admin", "payments", filters];
+    },
     users: () => ["admin", "users"],
     userProfile: (id) => ["admin", "users", String(id)],
   },


### PR DESCRIPTION
## Summary
- add admin payments query helpers to fetch and approve records from the backend
- update the admin payments page with real data filtering, optimistic approval, and refreshed status messaging
- refresh the dashboard payments table, query keys, and shared table component to display normalized payment details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68db94aff264832eac9c4aa753e60f51