### PR TITLE
Integrate real backend flows for password reset routes

### DIFF
--- a/src/app/api/password-reset/_relay.js
+++ b/src/app/api/password-reset/_relay.js
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+const BACKEND_BASE = (process.env.AUTH_BACKEND_URL || "http://localhost:5000").replace(/\/$/, "");
+const TIMEOUT_MS = Number(process.env.PASSWORD_RESET_TIMEOUT_MS || 15_000);
+
+export async function relayPasswordReset(req, backendPath) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const upstream = await fetch(`${BACKEND_BASE}${backendPath}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: await req.text(),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    const text = await upstream.text();
+    let data;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = text;
+    }
+
+    const init = { status: upstream.status };
+    if (data === null) {
+      return new NextResponse(null, init);
+    }
+
+    if (typeof data === "object") {
+      return NextResponse.json(data, init);
+    }
+
+    return new NextResponse(String(data), init);
+  } catch (error) {
+    const message = error.name === "AbortError"
+      ? "Password reset request timed out."
+      : "Unable to reach authentication service.";
+    return NextResponse.json({ message }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/app/api/password-reset/request/route.js
+++ b/src/app/api/password-reset/request/route.js
@@ -1,0 +1,5 @@
+import { relayPasswordReset } from "../_relay";
+
+export async function POST(req) {
+  return relayPasswordReset(req, "/api/users/request-password-reset");
+}

--- a/src/app/api/password-reset/reset/route.js
+++ b/src/app/api/password-reset/reset/route.js
@@ -1,0 +1,5 @@
+import { relayPasswordReset } from "../_relay";
+
+export async function POST(req) {
+  return relayPasswordReset(req, "/api/users/reset-password");
+}

--- a/src/components/features/auth/reset-password-form.js
+++ b/src/components/features/auth/reset-password-form.js
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
-const backendBaseUrl = (process.env.AUTH_BACKEND_URL || "http://localhost:4000").replace(/\/$/, "");
+const backendBaseUrl = process.env.AUTH_BACKEND_URL?.replace(/\/$/, "") ?? "http://localhost:4000";
 
 const resetSchema = z
   .object({

--- a/src/components/features/auth/reset-password-form.js
+++ b/src/components/features/auth/reset-password-form.js
@@ -12,8 +12,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
-const backendBaseUrl = (process.env.AUTH_BACKEND_URL || "http://localhost:5000").replace(/\/$/, "");
-
 const resetSchema = z
   .object({
     email: z.string().email("Enter a valid email"),
@@ -46,7 +44,7 @@ export function ResetPasswordForm() {
   const onSubmit = async (values) => {
     setIsSubmitting(true);
     try {
-      const response = await fetch(`${backendBaseUrl}/api/users/reset-password`, {
+      const response = await fetch("/api/password-reset/reset", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: values.email, otp: values.otp, newPassword: values.newPassword }),
@@ -125,7 +123,7 @@ export function RequestPasswordResetForm() {
   const onSubmit = async (values) => {
     setIsSubmitting(true);
     try {
-      const response = await fetch(`${backendBaseUrl}/api/users/request-password-reset`, {
+      const response = await fetch("/api/password-reset/request", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: values.email }),

--- a/src/components/features/auth/reset-password-form.js
+++ b/src/components/features/auth/reset-password-form.js
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
-const backendBaseUrl = process.env.AUTH_BACKEND_URL?.replace(/\/$/, "") ?? "http://localhost:4000";
+const backendBaseUrl = (process.env.AUTH_BACKEND_URL || "http://localhost:5000").replace(/\/$/, "");
 
 const resetSchema = z
   .object({

--- a/src/components/features/auth/reset-password-form.js
+++ b/src/components/features/auth/reset-password-form.js
@@ -12,6 +12,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
+const backendBaseUrl = (process.env.AUTH_BACKEND_URL || "http://localhost:4000").replace(/\/$/, "");
+
 const resetSchema = z
   .object({
     email: z.string().email("Enter a valid email"),
@@ -44,7 +46,7 @@ export function ResetPasswordForm() {
   const onSubmit = async (values) => {
     setIsSubmitting(true);
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:4000"}/api/users/reset-password`, {
+      const response = await fetch(`${backendBaseUrl}/api/users/reset-password`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: values.email, otp: values.otp, newPassword: values.newPassword }),
@@ -123,7 +125,7 @@ export function RequestPasswordResetForm() {
   const onSubmit = async (values) => {
     setIsSubmitting(true);
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:4000"}/api/users/request-password-reset`, {
+      const response = await fetch(`${backendBaseUrl}/api/users/request-password-reset`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: values.email }),


### PR DESCRIPTION
## Summary
- wire the forgot-password and reset-password forms to the live API responses and surface backend messages
- prefill the reset form email from the request flow and redirect after a successful password change
- tighten OTP validation and reuse form defaults while handling network errors gracefully

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dbbf5c2798832ea79c0d2b00840905