### PR TITLE
Add server proxy endpoint for registration form

### DIFF
--- a/src/app/api/register/route.js
+++ b/src/app/api/register/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+
+const BACKEND_BASE = (process.env.AUTH_BACKEND_URL || "http://localhost:5000").replace(/\/$/, "");
+const TIMEOUT_MS = Number(process.env.REGISTER_TIMEOUT_MS || 15_000);
+
+export async function POST(req) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const upstream = await fetch(`${BACKEND_BASE}/api/users/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: await req.text(),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    const text = await upstream.text();
+    let data;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = text;
+    }
+
+    const init = { status: upstream.status };
+    if (data === null) {
+      return new NextResponse(null, init);
+    }
+
+    if (typeof data === "object") {
+      return NextResponse.json(data, init);
+    }
+
+    return new NextResponse(String(data), init);
+  } catch (error) {
+    const message =
+      error.name === "AbortError"
+        ? "Registration request timed out."
+        : "Unable to reach authentication service.";
+    return NextResponse.json({ message }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/components/features/auth/register-form.js
+++ b/src/components/features/auth/register-form.js
@@ -39,7 +39,7 @@ export default function RegisterForm() {
   const onSubmit = async (values) => {
     setIsSubmitting(true);
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:4000"}/api/users/register`, {
+      const response = await fetch("/api/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username: values.username, email: values.email, password: values.password }),


### PR DESCRIPTION
## Summary
- add a server-side /api/register route that relays registration requests to the auth backend using AUTH_BACKEND_URL
- reuse the proxy pattern with timeout/error handling so the client no longer needs direct backend knowledge
- update the registration form to post to the new proxy endpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dc2206ee90832e8ae6e3ea81cb8bed