### PR TITLE
Integrate admin user management with backend APIs

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.js
+++ b/src/app/(admin)/admin/dashboard/page.js
@@ -5,10 +5,9 @@ import { useQuery } from "@tanstack/react-query";
 import PageHeader from "@/components/shared/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { fetchAdminUsers } from "@/lib/mock-data";
-import { qk } from "@/lib/query-keys";
 import { adminPlansOptions } from "@/lib/queries/admin-plans";
 import { adminPaymentsOptions } from "@/lib/queries/admin-payments";
+import { adminUsersOptions } from "@/lib/queries/admin-users";
 
 const formatCurrency = (amount, currency) => {
   if (amount == null) return "—";
@@ -49,7 +48,8 @@ export default function AdminDashboardPage() {
   const { data: plans = [] } = useQuery(adminPlansOptions());
   const { data: pendingPaymentsData } = useQuery(adminPaymentsOptions({ status: "pending" }));
   const { data: recentPaymentsData } = useQuery(adminPaymentsOptions());
-  const { data: users = [] } = useQuery({ queryKey: qk.admin.users(), queryFn: fetchAdminUsers });
+  const { data: usersData } = useQuery(adminUsersOptions());
+  const users = usersData?.items ?? [];
 
   const pendingPayments = pendingPaymentsData?.items ?? [];
   const pendingPaymentsCount = pendingPaymentsData?.pagination?.totalItems ?? pendingPayments.length;
@@ -94,7 +94,15 @@ export default function AdminDashboardPage() {
             <CardTitle>Enterprise Accounts</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-3xl font-semibold">{users.filter((user) => user.plan === "Enterprise").length}</p>
+            <p className="text-3xl font-semibold">
+              {
+                users.filter((user) => {
+                  const slug = user.planSlug?.toLowerCase();
+                  const name = user.planName?.toLowerCase();
+                  return slug === "enterprise" || name?.includes("enterprise");
+                }).length
+              }
+            </p>
             <p className="text-sm text-muted-foreground">Managed by customer success</p>
           </CardContent>
         </Card>

--- a/src/app/(admin)/admin/user-management/[userId]/page.js
+++ b/src/app/(admin)/admin/user-management/[userId]/page.js
@@ -1,61 +1,25 @@
 // File: src/app/(admin)/admin/user-management/[userId]/page.js
-import PageHeader from "@/components/shared/page-header";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { fetchAdminUserProfile } from "@/lib/mock-data";
+import { dehydrate } from "@tanstack/react-query";
+import HydrateClient from "@/components/HydrateClient";
+import { getQueryClient } from "@/app/get-query-client";
+import { adminUserProfileOptions, adminUsersOptions } from "@/lib/queries/admin-users";
+import UserProfileClient from "./user-profile-client";
 
-// Detailed user profile for administrators.
+// Server component responsible for prefetching user profile data for hydration.
 export default async function AdminUserProfilePage({ params }) {
-  const profile = await fetchAdminUserProfile(params.userId);
+  const userId = params.userId;
+  const queryClient = getQueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery(adminUserProfileOptions(userId)),
+    queryClient.prefetchQuery(adminUsersOptions()),
+  ]);
+
+  const state = dehydrate(queryClient);
 
   return (
-    <div className="space-y-8">
-      <PageHeader
-        title={`User: ${profile.username}`}
-        description={`Plan: ${profile.plan}`}
-        actions={<Button variant="outline">Reset password</Button>}
-      />
-      <div className="grid gap-6 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>Profile details</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            <div>
-              <p className="font-medium">Email</p>
-              <p className="text-muted-foreground">{profile.email}</p>
-            </div>
-            <div>
-              <p className="font-medium">Status</p>
-              <p className="text-muted-foreground">{profile.status}</p>
-            </div>
-            <div>
-              <p className="font-medium">Joined</p>
-              <p className="text-muted-foreground">{profile.registeredAt}</p>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Plan & permissions</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            <div>
-              <p className="font-medium">Current plan</p>
-              <p className="text-muted-foreground">{profile.plan}</p>
-            </div>
-            <div>
-              <p className="font-medium">Actions</p>
-              <div className="mt-2 flex gap-2">
-                <Button size="sm">Change plan</Button>
-                <Button size="sm" variant="outline">
-                  Update profile
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+    <HydrateClient state={state}>
+      <UserProfileClient userId={userId} />
+    </HydrateClient>
   );
 }

--- a/src/app/(admin)/admin/user-management/[userId]/page.js
+++ b/src/app/(admin)/admin/user-management/[userId]/page.js
@@ -7,7 +7,7 @@ import UserProfileClient from "./user-profile-client";
 
 // Server component responsible for prefetching user profile data for hydration.
 export default async function AdminUserProfilePage({ params }) {
-  const userId = params.userId;
+  const { userId } = await params;
   const queryClient = getQueryClient();
 
   await Promise.all([

--- a/src/app/(admin)/admin/user-management/[userId]/page.js
+++ b/src/app/(admin)/admin/user-management/[userId]/page.js
@@ -3,6 +3,7 @@ import { dehydrate } from "@tanstack/react-query";
 import HydrateClient from "@/components/HydrateClient";
 import { getQueryClient } from "@/app/get-query-client";
 import { adminUserProfileOptions, adminUsersOptions } from "@/lib/queries/admin-users";
+import { adminPlansOptions } from "@/lib/queries/admin-plans";
 import UserProfileClient from "./user-profile-client";
 
 // Server component responsible for prefetching user profile data for hydration.
@@ -13,6 +14,7 @@ export default async function AdminUserProfilePage({ params }) {
   await Promise.all([
     queryClient.prefetchQuery(adminUserProfileOptions(userId)),
     queryClient.prefetchQuery(adminUsersOptions()),
+    queryClient.prefetchQuery(adminPlansOptions()),
   ]);
 
   const state = dehydrate(queryClient);

--- a/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
+++ b/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
@@ -26,9 +26,6 @@ import {
 import { adminPlansOptions } from "@/lib/queries/admin-plans";
 
 const ROLE_OPTIONS = ["user", "admin", "editor", "support"];
-const NO_ROLE_VALUE = "__no_role__";
-const NO_PLAN_VALUE = "__no_plan__";
-const NO_SUBSCRIPTION_STATUS_VALUE = "__no_subscription_status__";
 const SUBSCRIPTION_STATUS_OPTIONS = [
   "active",
   "trialing",
@@ -554,16 +551,13 @@ export default function UserProfileClient({ userId }) {
                       <Label htmlFor="role">Role</Label>
                       <Select
                         value={toSelectValue(field.value)}
-                        onValueChange={(value) =>
-                          field.onChange(value === NO_ROLE_VALUE ? "" : value)
-                        }
+                        onValueChange={(value) => field.onChange(value ?? "")}
                         disabled={isSaving}
                       >
                         <SelectTrigger id="role">
                           <SelectValue placeholder="Select role" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value={NO_ROLE_VALUE}>No role</SelectItem>
                           {ROLE_OPTIONS.map((role) => (
                             <SelectItem key={role} value={role}>
                               {role}
@@ -583,9 +577,7 @@ export default function UserProfileClient({ userId }) {
                       <Label htmlFor="planId">Plan Slug</Label>
                       <Select
                         value={toSelectValue(field.value)}
-                        onValueChange={(value) =>
-                          field.onChange(value === NO_PLAN_VALUE ? "" : value)
-                        }
+                        onValueChange={(value) => field.onChange(value ?? "")}
                         disabled={isSaving || planSlugOptions.length === 0}
                       >
                         <SelectTrigger id="planId">
@@ -596,7 +588,6 @@ export default function UserProfileClient({ userId }) {
                           />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value={NO_PLAN_VALUE}>No plan</SelectItem>
                           {planSlugOptions.map((slug) => (
                             <SelectItem key={slug} value={slug}>
                               {slug}
@@ -616,18 +607,13 @@ export default function UserProfileClient({ userId }) {
                       <Label htmlFor="subscriptionStatus">Subscription status</Label>
                       <Select
                         value={toSelectValue(field.value)}
-                        onValueChange={(value) =>
-                          field.onChange(
-                            value === NO_SUBSCRIPTION_STATUS_VALUE ? "" : value
-                          )
-                        }
+                        onValueChange={(value) => field.onChange(value ?? "")}
                         disabled={isSaving}
                       >
                         <SelectTrigger id="subscriptionStatus">
                           <SelectValue placeholder="Select subscription status" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value={NO_SUBSCRIPTION_STATUS_VALUE}>No status</SelectItem>
                           {subscriptionStatusOptions.map((status) => (
                             <SelectItem key={status} value={status}>
                               {status}

--- a/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
+++ b/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
@@ -1,0 +1,621 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import PageHeader from "@/components/shared/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { toast } from "@/components/ui/sonner";
+import { qk } from "@/lib/query-keys";
+import {
+  adminUserProfileOptions,
+  adminUsersOptions,
+  updateAdminUser,
+  updateAdminUserStatus,
+  resetAdminUserPassword,
+  mergeAdminUser,
+  formatAdminUserStatus,
+} from "@/lib/queries/admin-users";
+
+const defaultFormValues = {
+  username: "",
+  email: "",
+  firstName: "",
+  lastName: "",
+  role: "",
+  planId: "",
+  profilePictureUrl: "",
+  subscriptionStatus: "",
+  subscriptionStartDate: "",
+  subscriptionEndDate: "",
+  trialEndsAt: "",
+  isActive: true,
+};
+
+const mapProfileToForm = (profile) => {
+  if (!profile) return defaultFormValues;
+  const toDateInput = (value) => {
+    if (!value) return "";
+    const str = String(value);
+    return str.length > 10 ? str.slice(0, 10) : str;
+  };
+  return {
+    username: profile.username ?? "",
+    email: profile.email ?? "",
+    firstName: profile.firstName ?? "",
+    lastName: profile.lastName ?? "",
+    role: profile.role ?? "",
+    planId: profile.planId ?? profile.planSlug ?? "",
+    profilePictureUrl: profile.profilePictureUrl ?? "",
+    subscriptionStatus: profile.subscriptionStatus ?? "",
+    subscriptionStartDate: toDateInput(profile.subscriptionStartDate),
+    subscriptionEndDate: toDateInput(profile.subscriptionEndDate),
+    trialEndsAt: toDateInput(profile.trialEndsAt),
+    isActive: Boolean(profile.isActive),
+  };
+};
+
+const getErrorMessage = (err, fallback) => {
+  if (!err) return fallback;
+  if (typeof err?.body === "string") return err.body;
+  if (err?.body?.message) return err.body.message;
+  if (err?.message) return err.message;
+  return fallback;
+};
+
+const buildUpdatePayload = (values, profile) => {
+  const payload = {};
+  const trimmedUsername = values.username?.trim();
+  if (trimmedUsername && trimmedUsername !== profile?.username) {
+    payload.username = trimmedUsername;
+  }
+  const trimmedEmail = values.email?.trim();
+  if (trimmedEmail && trimmedEmail !== profile?.email) {
+    payload.email = trimmedEmail;
+  }
+  const firstName = values.firstName?.trim() || null;
+  if ((profile?.firstName ?? null) !== firstName) {
+    payload.firstName = firstName;
+  }
+  const lastName = values.lastName?.trim() || null;
+  if ((profile?.lastName ?? null) !== lastName) {
+    payload.lastName = lastName;
+  }
+  const role = values.role?.trim();
+  if (role && role !== profile?.role) {
+    payload.role = role;
+  }
+  const planId = values.planId?.trim();
+  if (planId && planId !== profile?.planId && planId !== profile?.planSlug) {
+    payload.planId = planId;
+  }
+  const profilePictureUrl = values.profilePictureUrl?.trim() || null;
+  if ((profile?.profilePictureUrl ?? null) !== profilePictureUrl) {
+    payload.profilePictureUrl = profilePictureUrl;
+  }
+  const subscriptionStatus = values.subscriptionStatus?.trim() || null;
+  if ((profile?.subscriptionStatus ?? null) !== subscriptionStatus) {
+    payload.subscriptionStatus = subscriptionStatus;
+  }
+  const subscriptionStartDate = values.subscriptionStartDate ? values.subscriptionStartDate : null;
+  if ((profile?.subscriptionStartDate ?? null) !== subscriptionStartDate) {
+    payload.subscriptionStartDate = subscriptionStartDate;
+  }
+  const subscriptionEndDate = values.subscriptionEndDate ? values.subscriptionEndDate : null;
+  if ((profile?.subscriptionEndDate ?? null) !== subscriptionEndDate) {
+    payload.subscriptionEndDate = subscriptionEndDate;
+  }
+  const trialEndsAt = values.trialEndsAt ? values.trialEndsAt : null;
+  if ((profile?.trialEndsAt ?? null) !== trialEndsAt) {
+    payload.trialEndsAt = trialEndsAt;
+  }
+  const isActive = Boolean(values.isActive);
+  if (profile?.isActive !== isActive) {
+    payload.isActive = isActive;
+  }
+  return payload;
+};
+
+const initials = (value) => {
+  if (!value) return "??";
+  const parts = String(value)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((segment) => segment[0]?.toUpperCase())
+    .filter(Boolean);
+  if (parts.length >= 2) return parts.slice(0, 2).join("");
+  return parts[0] ?? String(value).slice(0, 2).toUpperCase();
+};
+
+export default function UserProfileClient({ userId }) {
+  const queryClient = useQueryClient();
+  const {
+    data: profile,
+    isLoading,
+    isError,
+    error,
+  } = useQuery(adminUserProfileOptions(userId));
+  const { data: listData } = useQuery(adminUsersOptions());
+
+  const form = useForm({ defaultValues: defaultFormValues });
+
+  useEffect(() => {
+    if (profile) {
+      form.reset(mapProfileToForm(profile));
+    }
+  }, [form, profile]);
+
+  const [statusValue, setStatusValue] = useState("");
+
+  useEffect(() => {
+    if (!profile) {
+      setStatusValue("");
+      return;
+    }
+    const nextStatus = profile.statusCode || (profile.status ? String(profile.status).toLowerCase() : "");
+    setStatusValue(nextStatus || "");
+  }, [profile?.statusCode, profile?.status]);
+
+  const statusOptions = useMemo(() => {
+    const set = new Set();
+    (listData?.availableStatuses ?? []).forEach((status) => {
+      if (!status) return;
+      const str = String(status).trim().toLowerCase();
+      if (str) set.add(str);
+    });
+    if (profile?.statusCode) set.add(String(profile.statusCode).trim().toLowerCase());
+    if (profile?.status) set.add(String(profile.status).trim().toLowerCase());
+    const result = Array.from(set);
+    if (result.length === 0 && statusValue) {
+      result.push(statusValue);
+    }
+    return result;
+  }, [listData?.availableStatuses, profile?.statusCode, profile?.status, statusValue]);
+
+  const errorMessage = isError ? getErrorMessage(error, "Failed to load user profile.") : null;
+
+  const updateProfileMutation = useMutation({
+    mutationFn: ({ userId: targetUserId, updates }) => updateAdminUser({ userId: targetUserId, updates }),
+    onMutate: async ({ userId: targetUserId, updates }) => {
+      await queryClient.cancelQueries({ queryKey: qk.admin.userProfile(targetUserId) });
+      await queryClient.cancelQueries({ queryKey: qk.admin.users(), exact: false });
+
+      const previousProfile = queryClient.getQueryData(qk.admin.userProfile(targetUserId));
+      const previousUserQueries = queryClient.getQueriesData({ queryKey: qk.admin.users(), exact: false });
+      const targetId = previousProfile?.id ?? targetUserId;
+
+      if (previousProfile) {
+        const optimisticProfile = mergeAdminUser(previousProfile, updates);
+        queryClient.setQueryData(qk.admin.userProfile(targetUserId), optimisticProfile);
+      }
+
+      previousUserQueries.forEach(([key, value]) => {
+        if (!value?.items) return;
+        const items = value.items.map((item) =>
+          item.id === targetId ? mergeAdminUser(item, updates) : item
+        );
+        queryClient.setQueryData(key, { ...value, items });
+      });
+
+      return { previousProfile, previousUserQueries };
+    },
+    onError: (mutationError, variables, context) => {
+      if (context?.previousProfile) {
+        queryClient.setQueryData(qk.admin.userProfile(variables.userId), context.previousProfile);
+      }
+      context?.previousUserQueries?.forEach(([key, value]) => {
+        queryClient.setQueryData(key, value);
+      });
+      toast.error(getErrorMessage(mutationError, "Failed to update profile."));
+    },
+    onSuccess: (response, variables, context) => {
+      const nextProfile = mergeAdminUser(
+        queryClient.getQueryData(qk.admin.userProfile(variables.userId)) || context?.previousProfile || null,
+        response
+      );
+      queryClient.setQueryData(qk.admin.userProfile(variables.userId), nextProfile);
+
+      const queries = queryClient.getQueriesData({ queryKey: qk.admin.users(), exact: false });
+      queries.forEach(([key]) => {
+        queryClient.setQueryData(key, (current) => {
+          if (!current?.items) return current;
+          const items = current.items.map((item) =>
+            item.id === nextProfile.id ? mergeAdminUser(item, response) : item
+          );
+          return { ...current, items };
+        });
+      });
+
+      form.reset(mapProfileToForm(nextProfile));
+      toast.success("Profile updated successfully.");
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: qk.admin.userProfile(variables.userId) });
+      queryClient.invalidateQueries({ queryKey: qk.admin.users(), exact: false });
+    },
+  });
+
+  const updateStatusMutation = useMutation({
+    mutationFn: ({ userId: targetUserId, status }) => updateAdminUserStatus({ userId: targetUserId, status }),
+    onMutate: async ({ userId: targetUserId, status }) => {
+      await queryClient.cancelQueries({ queryKey: qk.admin.userProfile(targetUserId) });
+      await queryClient.cancelQueries({ queryKey: qk.admin.users(), exact: false });
+
+      const previousProfile = queryClient.getQueryData(qk.admin.userProfile(targetUserId));
+      const previousUserQueries = queryClient.getQueriesData({ queryKey: qk.admin.users(), exact: false });
+      const targetId = previousProfile?.id ?? targetUserId;
+
+      if (previousProfile) {
+        const optimistic = mergeAdminUser(previousProfile, { statusCode: status, status });
+        queryClient.setQueryData(qk.admin.userProfile(targetUserId), optimistic);
+      }
+
+      previousUserQueries.forEach(([key, value]) => {
+        if (!value?.items) return;
+        const items = value.items.map((item) =>
+          item.id === targetId ? mergeAdminUser(item, { statusCode: status, status }) : item
+        );
+        queryClient.setQueryData(key, { ...value, items });
+      });
+
+      return { previousProfile, previousUserQueries };
+    },
+    onError: (mutationError, variables, context) => {
+      if (context?.previousProfile) {
+        queryClient.setQueryData(qk.admin.userProfile(variables.userId), context.previousProfile);
+      }
+      context?.previousUserQueries?.forEach(([key, value]) => {
+        queryClient.setQueryData(key, value);
+      });
+      toast.error(getErrorMessage(mutationError, "Failed to update status."));
+    },
+    onSuccess: (response, variables, context) => {
+      const resolvedStatus = (response?.statusCode ?? response?.status ?? variables.status) || "";
+      const normalizedStatus = String(resolvedStatus).trim().toLowerCase();
+      const patch = { statusCode: normalizedStatus, status: normalizedStatus };
+
+      const nextProfile = mergeAdminUser(
+        queryClient.getQueryData(qk.admin.userProfile(variables.userId)) || context?.previousProfile || null,
+        patch
+      );
+      queryClient.setQueryData(qk.admin.userProfile(variables.userId), nextProfile);
+
+      const queries = queryClient.getQueriesData({ queryKey: qk.admin.users(), exact: false });
+      queries.forEach(([key]) => {
+        queryClient.setQueryData(key, (current) => {
+          if (!current?.items) return current;
+          const items = current.items.map((item) =>
+            item.id === nextProfile.id ? mergeAdminUser(item, patch) : item
+          );
+          return { ...current, items };
+        });
+      });
+
+      setStatusValue(normalizedStatus);
+      toast.success(`Status updated to ${formatAdminUserStatus(normalizedStatus) || normalizedStatus}.`);
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: qk.admin.userProfile(variables.userId) });
+      queryClient.invalidateQueries({ queryKey: qk.admin.users(), exact: false });
+    },
+  });
+
+  const resetPasswordMutation = useMutation({
+    mutationFn: ({ userId: targetUserId, redirectUri }) =>
+      resetAdminUserPassword({ userId: targetUserId, redirectUri }),
+    onSuccess: (response) => {
+      toast.success(response?.message || "Password reset email scheduled.");
+    },
+    onError: (mutationError) => {
+      toast.error(getErrorMessage(mutationError, "Failed to schedule password reset."));
+    },
+  });
+
+  const handleSubmit = (values) => {
+    if (!profile) return;
+    const updates = buildUpdatePayload(values, profile);
+    if (Object.keys(updates).length === 0) {
+      toast.info("No changes detected.");
+      return;
+    }
+    updateProfileMutation.mutate({ userId, updates });
+  };
+
+  const handleResetPassword = () => {
+    const redirectUri =
+      typeof window !== "undefined" ? `${window.location.origin}/auth/reset-password` : undefined;
+    resetPasswordMutation.mutate({ userId, redirectUri });
+  };
+
+  const isSaving = updateProfileMutation.isPending;
+  const isUpdatingStatus = updateStatusMutation.isPending;
+  const isSendingReset = resetPasswordMutation.isPending;
+
+  const title = profile?.username
+    ? `User: ${profile.username}`
+    : profile?.email
+    ? `User: ${profile.email}`
+    : "User profile";
+  const description = profile?.planName
+    ? `Plan: ${profile.planName}`
+    : profile?.plan
+    ? `Plan: ${profile.plan}`
+    : "Manage account details, subscription, and permissions.";
+
+  if (isLoading && !profile) {
+    return (
+      <div className="space-y-8">
+        <PageHeader title="User profile" description="Loading profile details..." />
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            Loading user information…
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <div className="space-y-8">
+        <PageHeader title="User profile" description="Unable to load user details." />
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-destructive">{errorMessage}</CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={title}
+        description={description}
+        actions={
+          <Button variant="outline" onClick={handleResetPassword} disabled={isSendingReset}>
+            {isSendingReset ? "Sending…" : "Reset password"}
+          </Button>
+        }
+      />
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Update profile</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form className="grid gap-4" onSubmit={form.handleSubmit(handleSubmit)}>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-2">
+                  <Label htmlFor="username">Username</Label>
+                  <Input id="username" placeholder="Username" disabled={isSaving} {...form.register("username")} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input id="email" type="email" placeholder="user@example.com" disabled={isSaving} {...form.register("email")} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="firstName">First name</Label>
+                  <Input id="firstName" placeholder="First" disabled={isSaving} {...form.register("firstName")} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="lastName">Last name</Label>
+                  <Input id="lastName" placeholder="Last" disabled={isSaving} {...form.register("lastName")} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="role">Role</Label>
+                  <Input id="role" placeholder="user" disabled={isSaving} {...form.register("role")} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="planId">Plan ID</Label>
+                  <Input id="planId" placeholder="basic" disabled={isSaving} {...form.register("planId")} />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="subscriptionStatus">Subscription status</Label>
+                  <Input
+                    id="subscriptionStatus"
+                    placeholder="active"
+                    disabled={isSaving}
+                    {...form.register("subscriptionStatus")}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="profilePictureUrl">Profile picture URL</Label>
+                  <Input
+                    id="profilePictureUrl"
+                    placeholder="https://"
+                    disabled={isSaving}
+                    {...form.register("profilePictureUrl")}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="subscriptionStartDate">Subscription start</Label>
+                  <Input
+                    id="subscriptionStartDate"
+                    type="date"
+                    disabled={isSaving}
+                    {...form.register("subscriptionStartDate")}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="subscriptionEndDate">Subscription end</Label>
+                  <Input
+                    id="subscriptionEndDate"
+                    type="date"
+                    disabled={isSaving}
+                    {...form.register("subscriptionEndDate")}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="trialEndsAt">Trial ends</Label>
+                  <Input id="trialEndsAt" type="date" disabled={isSaving} {...form.register("trialEndsAt")} />
+                </div>
+              </div>
+              <Controller
+                control={form.control}
+                name="isActive"
+                render={({ field }) => (
+                  <div className="flex flex-col gap-3 rounded-md border p-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-1">
+                      <Label htmlFor="isActive">Active account</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Disable to revoke access to the platform without deleting the account.
+                      </p>
+                    </div>
+                    <Switch
+                      id="isActive"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={isSaving}
+                    />
+                  </div>
+                )}
+              />
+              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => profile && form.reset(mapProfileToForm(profile))}
+                  disabled={isSaving || !profile}
+                  className="w-full sm:w-auto"
+                >
+                  Reset
+                </Button>
+                <Button type="submit" disabled={isSaving} className="w-full sm:w-auto">
+                  {isSaving ? "Saving…" : "Save changes"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="flex flex-col gap-4">
+              <div className="flex items-center gap-4">
+                <Avatar className="size-16">
+                  <AvatarImage src={profile?.profilePictureUrl ?? undefined} alt={profile?.username ?? profile?.email ?? "User avatar"} />
+                  <AvatarFallback>{initials(profile?.fullName || profile?.username || profile?.email)}</AvatarFallback>
+                </Avatar>
+                <div className="space-y-1">
+                  <CardTitle>{profile?.fullName || profile?.username || profile?.email || "User"}</CardTitle>
+                  <div className="flex flex-wrap gap-2">
+                    {profile?.statusLabel ? (
+                      <Badge variant={profile?.isActive ? "default" : "secondary"}>{profile.statusLabel}</Badge>
+                    ) : null}
+                    {profile?.role ? <Badge variant="outline">{profile.role}</Badge> : null}
+                  </div>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm">
+              <div>
+                <p className="font-medium">Email</p>
+                <p className="text-muted-foreground">{profile?.email || "—"}</p>
+              </div>
+              <div>
+                <p className="font-medium">Plan</p>
+                <p className="text-muted-foreground">{profile?.planName || profile?.plan || "—"}</p>
+              </div>
+              <div>
+                <p className="font-medium">Subscription</p>
+                <p className="text-muted-foreground">
+                  {profile?.subscriptionStartDateLabel || profile?.subscriptionEndDateLabel
+                    ? `${profile?.subscriptionStartDateLabel ?? "—"} → ${profile?.subscriptionEndDateLabel ?? "—"}`
+                    : "—"}
+                </p>
+              </div>
+              <div>
+                <p className="font-medium">Registered</p>
+                <p className="text-muted-foreground">{profile?.registeredAtDateTimeLabel || profile?.registeredAtLabel || "—"}</p>
+              </div>
+              <div>
+                <p className="font-medium">Last login</p>
+                <p className="text-muted-foreground">{profile?.lastLoginAtLabel || "—"}</p>
+              </div>
+              <div>
+                <p className="font-medium">Trial ends</p>
+                <p className="text-muted-foreground">{profile?.trialEndsAtLabel || "—"}</p>
+              </div>
+              <div>
+                <p className="font-medium">User ID</p>
+                <p className="text-muted-foreground break-all">{profile?.id || userId}</p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Account status</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="status-select">Status</Label>
+                <Select
+                  value={statusValue}
+                  onValueChange={setStatusValue}
+                  disabled={isUpdatingStatus || statusOptions.length === 0}
+                >
+                  <SelectTrigger id="status-select">
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {statusOptions.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {formatAdminUserStatus(status) || status}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-sm text-muted-foreground">
+                  Adjust the account lifecycle to activate, pause, or suspend access.
+                </p>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                  type="button"
+                  onClick={() => statusValue && updateStatusMutation.mutate({ userId, status: statusValue })}
+                  disabled={!statusValue || isUpdatingStatus}
+                  className="w-full sm:w-auto"
+                >
+                  {isUpdatingStatus ? "Updating…" : "Apply status"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    setStatusValue(profile?.statusCode || (profile?.status ? String(profile.status).toLowerCase() : ""))
+                  }
+                  disabled={isUpdatingStatus || !profile}
+                  className="w-full sm:w-auto"
+                >
+                  Reset
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Security</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div>
+                <p className="font-medium">Password reset</p>
+                <p className="text-muted-foreground">
+                  Send a reset link to {profile?.email || "the user"}. The link will redirect to the hosted reset flow.
+                </p>
+              </div>
+              <Button onClick={handleResetPassword} disabled={isSendingReset} className="w-full">
+                {isSendingReset ? "Sending…" : "Send reset email"}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
+++ b/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
@@ -38,6 +38,12 @@ const SUBSCRIPTION_STATUS_OPTIONS = [
   "free",
 ];
 
+const toSelectValue = (value) => {
+  if (value == null) return undefined;
+  const trimmed = String(value).trim();
+  return trimmed.length ? trimmed : undefined;
+};
+
 const defaultFormValues = {
   username: "",
   email: "",
@@ -53,6 +59,26 @@ const defaultFormValues = {
   isActive: true,
 };
 
+const matchSelectOption = (value, options) => {
+  if (!value) return "";
+  const trimmed = String(value).trim();
+  if (!trimmed) return "";
+  if (!Array.isArray(options) || options.length === 0) return trimmed;
+  const lower = trimmed.toLowerCase();
+  const matched = options.find((option) => option.toLowerCase() === lower);
+  return matched ?? trimmed;
+};
+
+const resolvePlanFieldValue = (profile) => {
+  if (!profile) return "";
+  const slug =
+    typeof profile.planSlug === "string" ? profile.planSlug.trim() : "";
+  if (slug) return slug;
+  const planId =
+    typeof profile.planId === "string" ? profile.planId.trim() : "";
+  return planId;
+};
+
 const mapProfileToForm = (profile) => {
   if (!profile) return defaultFormValues;
   const toDateInput = (value) => {
@@ -65,10 +91,13 @@ const mapProfileToForm = (profile) => {
     email: profile.email ?? "",
     firstName: profile.firstName ?? "",
     lastName: profile.lastName ?? "",
-    role: profile.role ?? "",
-    planId: profile.planId ?? profile.planSlug ?? "",
+    role: matchSelectOption(profile.role, ROLE_OPTIONS),
+    planId: resolvePlanFieldValue(profile),
     profilePictureUrl: profile.profilePictureUrl ?? "",
-    subscriptionStatus: profile.subscriptionStatus ?? "",
+    subscriptionStatus: matchSelectOption(
+      profile.subscriptionStatus,
+      SUBSCRIPTION_STATUS_OPTIONS
+    ),
     subscriptionStartDate: toDateInput(profile.subscriptionStartDate),
     subscriptionEndDate: toDateInput(profile.subscriptionEndDate),
     trialEndsAt: toDateInput(profile.trialEndsAt),
@@ -524,7 +553,7 @@ export default function UserProfileClient({ userId }) {
                     <div className="grid gap-2">
                       <Label htmlFor="role">Role</Label>
                       <Select
-                        value={field.value || NO_ROLE_VALUE}
+                        value={toSelectValue(field.value)}
                         onValueChange={(value) =>
                           field.onChange(value === NO_ROLE_VALUE ? "" : value)
                         }
@@ -553,7 +582,7 @@ export default function UserProfileClient({ userId }) {
                     <div className="grid gap-2">
                       <Label htmlFor="planId">Plan Slug</Label>
                       <Select
-                        value={field.value || NO_PLAN_VALUE}
+                        value={toSelectValue(field.value)}
                         onValueChange={(value) =>
                           field.onChange(value === NO_PLAN_VALUE ? "" : value)
                         }
@@ -586,9 +615,11 @@ export default function UserProfileClient({ userId }) {
                     <div className="grid gap-2">
                       <Label htmlFor="subscriptionStatus">Subscription status</Label>
                       <Select
-                        value={field.value || NO_SUBSCRIPTION_STATUS_VALUE}
+                        value={toSelectValue(field.value)}
                         onValueChange={(value) =>
-                          field.onChange(value === NO_SUBSCRIPTION_STATUS_VALUE ? "" : value)
+                          field.onChange(
+                            value === NO_SUBSCRIPTION_STATUS_VALUE ? "" : value
+                          )
                         }
                         disabled={isSaving}
                       >

--- a/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
+++ b/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
@@ -190,13 +190,32 @@ export default function UserProfileClient({ userId }) {
     select: (plans) => (Array.isArray(plans) ? plans : []),
   });
 
+  const formValues = useMemo(
+    () =>
+      mapProfileToForm(profile),
+    [
+      profile?.id,
+      profile?.username,
+      profile?.email,
+      profile?.firstName,
+      profile?.lastName,
+      profile?.role,
+      profile?.planId,
+      profile?.planSlug,
+      profile?.profilePictureUrl,
+      profile?.subscriptionStatus,
+      profile?.subscriptionStartDate,
+      profile?.subscriptionEndDate,
+      profile?.trialEndsAt,
+      profile?.isActive,
+    ]
+  );
+
   const form = useForm({ defaultValues: defaultFormValues });
 
   useEffect(() => {
-    if (profile) {
-      form.reset(mapProfileToForm(profile));
-    }
-  }, [form, profile]);
+    form.reset(formValues);
+  }, [form, formValues]);
 
   const [statusValue, setStatusValue] = useState("");
 

--- a/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
+++ b/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
@@ -24,6 +24,16 @@ import {
   formatAdminUserStatus,
 } from "@/lib/queries/admin-users";
 
+const ROLE_OPTIONS = ["user", "admin", "editor", "support"];
+const SUBSCRIPTION_STATUS_OPTIONS = [
+  "active",
+  "trialing",
+  "canceled",
+  "past_due",
+  "pending",
+  "free",
+];
+
 const defaultFormValues = {
   username: "",
   email: "",
@@ -206,6 +216,18 @@ export default function UserProfileClient({ userId }) {
     }
     return result;
   }, [listData?.availableStatuses, profile?.statusCode, profile?.status, statusValue]);
+
+  const planSlugOptions = useMemo(() => {
+    const set = new Set();
+    (listData?.items ?? []).forEach((item) => {
+      const slug = item?.planSlug || item?.planId;
+      const value = typeof slug === "string" ? slug.trim() : "";
+      if (value) set.add(value);
+    });
+    if (profile?.planSlug) set.add(profile.planSlug);
+    if (profile?.planId) set.add(profile.planId);
+    return Array.from(set).sort();
+  }, [listData?.items, profile?.planId, profile?.planSlug]);
 
   const errorMessage = isError ? getErrorMessage(error, "Failed to load user profile.") : null;
 
@@ -440,23 +462,84 @@ export default function UserProfileClient({ userId }) {
                   <Label htmlFor="lastName">Last name</Label>
                   <Input id="lastName" placeholder="Last" disabled={isSaving} {...form.register("lastName")} />
                 </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="role">Role</Label>
-                  <Input id="role" placeholder="user" disabled={isSaving} {...form.register("role")} />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="planId">Plan ID</Label>
-                  <Input id="planId" placeholder="basic" disabled={isSaving} {...form.register("planId")} />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="subscriptionStatus">Subscription status</Label>
-                  <Input
-                    id="subscriptionStatus"
-                    placeholder="active"
-                    disabled={isSaving}
-                    {...form.register("subscriptionStatus")}
-                  />
-                </div>
+                <Controller
+                  control={form.control}
+                  name="role"
+                  render={({ field }) => (
+                    <div className="grid gap-2">
+                      <Label htmlFor="role">Role</Label>
+                      <Select
+                        value={field.value || ""}
+                        onValueChange={field.onChange}
+                        disabled={isSaving}
+                      >
+                        <SelectTrigger id="role">
+                          <SelectValue placeholder="Select role" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="">No role</SelectItem>
+                          {ROLE_OPTIONS.map((role) => (
+                            <SelectItem key={role} value={role}>
+                              {role}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="planId"
+                  render={({ field }) => (
+                    <div className="grid gap-2">
+                      <Label htmlFor="planId">Plan Slug</Label>
+                      <Select
+                        value={field.value || ""}
+                        onValueChange={field.onChange}
+                        disabled={isSaving || planSlugOptions.length === 0}
+                      >
+                        <SelectTrigger id="planId">
+                          <SelectValue placeholder={planSlugOptions.length ? "Select plan slug" : "No plan slugs"} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="">No plan</SelectItem>
+                          {planSlugOptions.map((slug) => (
+                            <SelectItem key={slug} value={slug}>
+                              {slug}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="subscriptionStatus"
+                  render={({ field }) => (
+                    <div className="grid gap-2">
+                      <Label htmlFor="subscriptionStatus">Subscription status</Label>
+                      <Select
+                        value={field.value || ""}
+                        onValueChange={field.onChange}
+                        disabled={isSaving}
+                      >
+                        <SelectTrigger id="subscriptionStatus">
+                          <SelectValue placeholder="Select subscription status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="">No status</SelectItem>
+                          {SUBSCRIPTION_STATUS_OPTIONS.map((status) => (
+                            <SelectItem key={status} value={status}>
+                              {status}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                />
                 <div className="grid gap-2">
                   <Label htmlFor="profilePictureUrl">Profile picture URL</Label>
                   <Input

--- a/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
+++ b/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
@@ -81,7 +81,8 @@ const normalizeStatusValue = (value) => {
 const getAccountStatusLabel = (value) => {
   const normalized = normalizeStatusValue(value);
   const match = ACCOUNT_STATUS_OPTIONS.find((option) => option.value === normalized);
-  return match?.label ?? formatAdminUserStatus(normalized) ?? normalized || "";
+  const label = match?.label ?? formatAdminUserStatus(normalized) ?? normalized;
+  return label || "";
 };
 
 const resolvePlanFieldValue = (profile) => {

--- a/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
+++ b/src/app/(admin)/admin/user-management/[userId]/user-profile-client.jsx
@@ -25,6 +25,9 @@ import {
 } from "@/lib/queries/admin-users";
 
 const ROLE_OPTIONS = ["user", "admin", "editor", "support"];
+const NO_ROLE_VALUE = "__no_role__";
+const NO_PLAN_VALUE = "__no_plan__";
+const NO_SUBSCRIPTION_STATUS_VALUE = "__no_subscription_status__";
 const SUBSCRIPTION_STATUS_OPTIONS = [
   "active",
   "trialing",
@@ -469,15 +472,17 @@ export default function UserProfileClient({ userId }) {
                     <div className="grid gap-2">
                       <Label htmlFor="role">Role</Label>
                       <Select
-                        value={field.value || ""}
-                        onValueChange={field.onChange}
+                        value={field.value || NO_ROLE_VALUE}
+                        onValueChange={(value) =>
+                          field.onChange(value === NO_ROLE_VALUE ? "" : value)
+                        }
                         disabled={isSaving}
                       >
                         <SelectTrigger id="role">
                           <SelectValue placeholder="Select role" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="">No role</SelectItem>
+                          <SelectItem value={NO_ROLE_VALUE}>No role</SelectItem>
                           {ROLE_OPTIONS.map((role) => (
                             <SelectItem key={role} value={role}>
                               {role}
@@ -495,15 +500,21 @@ export default function UserProfileClient({ userId }) {
                     <div className="grid gap-2">
                       <Label htmlFor="planId">Plan Slug</Label>
                       <Select
-                        value={field.value || ""}
-                        onValueChange={field.onChange}
+                        value={field.value || NO_PLAN_VALUE}
+                        onValueChange={(value) =>
+                          field.onChange(value === NO_PLAN_VALUE ? "" : value)
+                        }
                         disabled={isSaving || planSlugOptions.length === 0}
                       >
                         <SelectTrigger id="planId">
-                          <SelectValue placeholder={planSlugOptions.length ? "Select plan slug" : "No plan slugs"} />
+                          <SelectValue
+                            placeholder={
+                              planSlugOptions.length ? "Select plan slug" : "No plan slugs"
+                            }
+                          />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="">No plan</SelectItem>
+                          <SelectItem value={NO_PLAN_VALUE}>No plan</SelectItem>
                           {planSlugOptions.map((slug) => (
                             <SelectItem key={slug} value={slug}>
                               {slug}
@@ -521,15 +532,17 @@ export default function UserProfileClient({ userId }) {
                     <div className="grid gap-2">
                       <Label htmlFor="subscriptionStatus">Subscription status</Label>
                       <Select
-                        value={field.value || ""}
-                        onValueChange={field.onChange}
+                        value={field.value || NO_SUBSCRIPTION_STATUS_VALUE}
+                        onValueChange={(value) =>
+                          field.onChange(value === NO_SUBSCRIPTION_STATUS_VALUE ? "" : value)
+                        }
                         disabled={isSaving}
                       >
                         <SelectTrigger id="subscriptionStatus">
                           <SelectValue placeholder="Select subscription status" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="">No status</SelectItem>
+                          <SelectItem value={NO_SUBSCRIPTION_STATUS_VALUE}>No status</SelectItem>
                           {SUBSCRIPTION_STATUS_OPTIONS.map((status) => (
                             <SelectItem key={status} value={status}>
                               {status}

--- a/src/app/(admin)/admin/user-management/page.js
+++ b/src/app/(admin)/admin/user-management/page.js
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import PageHeader from "@/components/shared/page-header";
 import UserTable from "@/components/features/admin/user-table";
+import CreateUserDialog from "@/components/features/admin/create-user-dialog";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { adminUsersOptions, formatAdminUserStatus } from "@/lib/queries/admin-users";
@@ -22,6 +24,7 @@ const getErrorMessage = (err, fallback) => {
 export default function AdminUserManagementPage() {
   const router = useRouter();
   const [statusFilter, setStatusFilter] = useState("all");
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
 
   const { data, isLoading, isError, error } = useQuery(
     adminUsersOptions(statusFilter === "all" ? {} : { status: statusFilter })
@@ -45,7 +48,11 @@ export default function AdminUserManagementPage() {
       <PageHeader
         title="User management"
         description="Search, filter, and inspect customer accounts."
+        actions={
+          <Button onClick={() => setIsCreateOpen(true)}>Create user</Button>
+        }
       />
+      <CreateUserDialog open={isCreateOpen} onOpenChange={setIsCreateOpen} />
       <Card>
         <CardContent className="space-y-6 pt-6">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/app/(admin)/admin/user-management/page.js
+++ b/src/app/(admin)/admin/user-management/page.js
@@ -1,18 +1,44 @@
 // File: src/app/(admin)/admin/user-management/page.js
 "use client";
 
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import PageHeader from "@/components/shared/page-header";
 import UserTable from "@/components/features/admin/user-table";
 import { Card, CardContent } from "@/components/ui/card";
-import { qk } from "@/lib/query-keys";
-import { fetchAdminUsers } from "@/lib/mock-data";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { adminUsersOptions, formatAdminUserStatus } from "@/lib/queries/admin-users";
 
-// Administrative user list with search and navigation to detail view.
+const getErrorMessage = (err, fallback) => {
+  if (!err) return fallback;
+  if (typeof err?.body === "string") return err.body;
+  if (err?.body?.message) return err.body.message;
+  if (err?.message) return err.message;
+  return fallback;
+};
+
+// Administrative user list with search, server-backed filtering, and navigation to detail view.
 export default function AdminUserManagementPage() {
   const router = useRouter();
-  const { data: users = [] } = useQuery({ queryKey: qk.admin.users(), queryFn: fetchAdminUsers });
+  const [statusFilter, setStatusFilter] = useState("all");
+
+  const { data, isLoading, isError, error } = useQuery(
+    adminUsersOptions(statusFilter === "all" ? {} : { status: statusFilter })
+  );
+
+  const users = data?.items ?? [];
+  const statusOptions = useMemo(() => {
+    const set = new Set(["all"]);
+    (data?.availableStatuses ?? []).forEach((status) => {
+      if (!status) return;
+      set.add(String(status));
+    });
+    if (statusFilter) set.add(statusFilter);
+    return Array.from(set);
+  }, [data?.availableStatuses, statusFilter]);
+
+  const errorMessage = isError ? getErrorMessage(error, "Failed to load users.") : null;
 
   return (
     <div className="space-y-8">
@@ -21,8 +47,42 @@ export default function AdminUserManagementPage() {
         description="Search, filter, and inspect customer accounts."
       />
       <Card>
-        <CardContent className="pt-6">
-          <UserTable users={users} onViewProfile={(user) => router.push(`/admin/user-management/${user.id}`)} />
+        <CardContent className="space-y-6 pt-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Accounts</h2>
+              <p className="text-sm text-muted-foreground">
+                {users.length} user{users.length === 1 ? "" : "s"}
+                {statusFilter !== "all" && statusFilter ? ` • ${formatAdminUserStatus(statusFilter) ?? statusFilter}` : ""}
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <span className="text-sm text-muted-foreground sm:text-right">Status</span>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="w-full sm:w-48">
+                  <SelectValue placeholder="All statuses" />
+                </SelectTrigger>
+                <SelectContent>
+                  {statusOptions.map((status) => (
+                    <SelectItem key={status} value={status}>
+                      {status === "all" ? "All statuses" : formatAdminUserStatus(status) || status}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {isLoading ? (
+            <div className="py-12 text-center text-sm text-muted-foreground">Loading users…</div>
+          ) : (
+            <UserTable
+              users={users}
+              onViewProfile={(user) => router.push(`/admin/user-management/${user.id}`)}
+            />
+          )}
+
+          {errorMessage ? <p className="text-sm text-destructive">{errorMessage}</p> : null}
         </CardContent>
       </Card>
     </div>

--- a/src/components/features/admin/create-user-dialog.js
+++ b/src/components/features/admin/create-user-dialog.js
@@ -186,11 +186,12 @@ export default function CreateUserDialog({ open, onOpenChange }) {
   });
 
   useEffect(() => {
-    if (open) {
-      form.reset(defaultValues);
-      createUserMutation.reset();
-    }
-  }, [open, form, createUserMutation]);
+    if (!open) return;
+
+    form.reset(defaultValues);
+    createUserMutation.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const isSubmitting = createUserMutation.isPending;
 

--- a/src/components/features/admin/create-user-dialog.js
+++ b/src/components/features/admin/create-user-dialog.js
@@ -1,0 +1,370 @@
+// File: src/components/features/admin/create-user-dialog.js
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Controller, useForm } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "@/components/ui/sonner";
+import { adminPlansOptions } from "@/lib/queries/admin-plans";
+import { createAdminUser, normalizeAdminUser } from "@/lib/queries/admin-users";
+import { qk } from "@/lib/query-keys";
+
+const ROLE_OPTIONS = ["user", "admin", "editor", "support"];
+const SUBSCRIPTION_STATUS_OPTIONS = ["active", "trialing", "canceled", "past_due", "pending", "free"];
+const NONE_VALUE = "__none__";
+
+const schema = z.object({
+  username: z.string().min(3, "Username is required"),
+  email: z.string().email("Enter a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  role: z.string().optional(),
+  planSlug: z.string().optional(),
+  subscriptionStatus: z.string().optional(),
+});
+
+const defaultValues = {
+  username: "",
+  email: "",
+  password: "",
+  role: undefined,
+  planSlug: undefined,
+  subscriptionStatus: undefined,
+};
+
+const getErrorMessage = (err, fallback) => {
+  if (!err) return fallback;
+  if (typeof err?.body === "string") return err.body;
+  if (err?.body?.message) return err.body.message;
+  if (err?.message) return err.message;
+  return fallback;
+};
+
+// Dialog for provisioning a new admin-managed user account.
+export default function CreateUserDialog({ open, onOpenChange }) {
+  const form = useForm({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  const queryClient = useQueryClient();
+
+  const { data: plansData = [] } = useQuery({
+    ...adminPlansOptions(),
+    enabled: open,
+    placeholderData: (previous) => previous ?? [],
+    select: (plans) => (Array.isArray(plans) ? plans : []),
+  });
+
+  const planLookup = useMemo(() => {
+    const map = new Map();
+    plansData.forEach((plan) => {
+      if (!plan?.slug || typeof plan.slug !== "string") return;
+      const slug = plan.slug.trim();
+      if (!slug) return;
+      map.set(slug, plan);
+    });
+    return map;
+  }, [plansData]);
+
+  const planSlugOptions = useMemo(() => {
+    const set = new Set();
+    plansData.forEach((plan) => {
+      if (!plan?.slug || typeof plan.slug !== "string") return;
+      if (!plan.isPublic) return;
+      const slug = plan.slug.trim();
+      if (!slug) return;
+      set.add(slug);
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [plansData]);
+
+  const createUserMutation = useMutation({
+    mutationFn: (input) => createAdminUser(input),
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: qk.admin.users(), exact: false });
+      const queries = queryClient.getQueriesData({ queryKey: qk.admin.users(), exact: false });
+      const tempId = `temp-${Date.now()}`;
+      const planIdentifier = variables.planId ?? null;
+      const selectedPlan = planIdentifier ? planLookup.get(planIdentifier) : null;
+      const timestamp = new Date().toISOString();
+      const optimisticRaw = {
+        _id: tempId,
+        id: tempId,
+        username: variables.username,
+        email: variables.email,
+        role: variables.role ?? null,
+        planId: planIdentifier,
+        planSlug: selectedPlan?.slug ?? planIdentifier,
+        plan: selectedPlan?.name ?? null,
+        planName: selectedPlan?.name ?? null,
+        subscriptionStatus: variables.subscriptionStatus ?? null,
+        status: variables.subscriptionStatus ?? null,
+        statusCode: variables.subscriptionStatus ?? null,
+        isActive: true,
+        registeredAt: timestamp,
+        createdAt: timestamp,
+      };
+      const optimisticUser = normalizeAdminUser({ ...optimisticRaw, raw: optimisticRaw });
+
+      const snapshots = queries.map(([key, data]) => {
+        queryClient.setQueryData(key, (current) => {
+          if (!current) {
+            const availableStatuses = optimisticUser.statusCode ? [optimisticUser.statusCode] : [];
+            return {
+              items: [optimisticUser],
+              pagination: null,
+              availableStatuses,
+              raw: undefined,
+            };
+          }
+
+          const items = Array.isArray(current.items) ? [optimisticUser, ...current.items] : [optimisticUser];
+          const statusSet = new Set(current.availableStatuses ?? []);
+          if (optimisticUser.statusCode) {
+            statusSet.add(optimisticUser.statusCode);
+          }
+
+          return {
+            ...current,
+            items,
+            availableStatuses: Array.from(statusSet),
+          };
+        });
+        return [key, data];
+      });
+
+      return { snapshots, tempId, optimisticUser };
+    },
+    onError: (error, _variables, context) => {
+      context?.snapshots?.forEach(([key, previous]) => {
+        queryClient.setQueryData(key, previous);
+      });
+      toast.error(getErrorMessage(error, "Failed to create user."));
+    },
+    onSuccess: (data, _variables, context) => {
+      const normalized = data ? normalizeAdminUser({ ...data, raw: data }) : null;
+      const replacement = normalized ?? context?.optimisticUser ?? null;
+
+      if (replacement && context?.snapshots) {
+        context.snapshots.forEach(([key]) => {
+          queryClient.setQueryData(key, (current) => {
+            if (!current?.items) return current;
+            const filtered = current.items.filter((item) => item.id !== context.tempId);
+            return {
+              ...current,
+              items: [replacement, ...filtered],
+            };
+          });
+        });
+      }
+
+      toast.success("User created successfully.");
+      form.reset(defaultValues);
+      onOpenChange?.(false);
+    },
+    onSettled: (_data, _error, _variables, context) => {
+      queryClient.invalidateQueries({ queryKey: qk.admin.users(), exact: false });
+      if (context?.tempId) {
+        queryClient.removeQueries({ queryKey: ["admin", "users", context.tempId] });
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset(defaultValues);
+      createUserMutation.reset();
+    }
+  }, [open, form, createUserMutation]);
+
+  const isSubmitting = createUserMutation.isPending;
+
+  const handleSubmit = async (values) => {
+    const payload = {
+      username: values.username.trim(),
+      email: values.email.trim(),
+      password: values.password,
+    };
+
+    if (values.role) {
+      payload.role = values.role;
+    }
+
+    if (values.planSlug) {
+      payload.planId = values.planSlug;
+    }
+
+    if (values.subscriptionStatus) {
+      payload.subscriptionStatus = values.subscriptionStatus;
+    }
+
+    try {
+      await createUserMutation.mutateAsync(payload);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create user</DialogTitle>
+          <DialogDescription>
+            Provision a new account and immediately sync it across administrative views.
+          </DialogDescription>
+        </DialogHeader>
+        <form id="create-user-form" className="space-y-4" onSubmit={form.handleSubmit(handleSubmit)}>
+          <div className="grid gap-2">
+            <Label htmlFor="create-username">Username</Label>
+            <Input
+              id="create-username"
+              placeholder="username"
+              disabled={isSubmitting}
+              {...form.register("username")}
+            />
+            {form.formState.errors.username ? (
+              <p className="text-sm text-destructive">{form.formState.errors.username.message}</p>
+            ) : null}
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="create-email">Email</Label>
+            <Input
+              id="create-email"
+              type="email"
+              placeholder="user@example.com"
+              disabled={isSubmitting}
+              {...form.register("email")}
+            />
+            {form.formState.errors.email ? (
+              <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
+            ) : null}
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="create-password">Temporary password</Label>
+            <Input
+              id="create-password"
+              type="password"
+              placeholder="********"
+              disabled={isSubmitting}
+              {...form.register("password")}
+            />
+            {form.formState.errors.password ? (
+              <p className="text-sm text-destructive">{form.formState.errors.password.message}</p>
+            ) : null}
+          </div>
+          <Controller
+            control={form.control}
+            name="role"
+            render={({ field }) => (
+              <div className="grid gap-2">
+                <Label htmlFor="create-role">Role</Label>
+                <Select
+                  disabled={isSubmitting}
+                  value={field.value ?? NONE_VALUE}
+                  onValueChange={(value) => field.onChange(value === NONE_VALUE ? undefined : value)}
+                >
+                  <SelectTrigger id="create-role">
+                    <SelectValue placeholder="Select role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NONE_VALUE}>No role</SelectItem>
+                    {ROLE_OPTIONS.map((role) => (
+                      <SelectItem key={role} value={role}>
+                        {role}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          />
+          <Controller
+            control={form.control}
+            name="planSlug"
+            render={({ field }) => (
+              <div className="grid gap-2">
+                <Label htmlFor="create-plan">Plan Slug</Label>
+                <Select
+                  disabled={isSubmitting || planSlugOptions.length === 0}
+                  value={field.value ?? NONE_VALUE}
+                  onValueChange={(value) => field.onChange(value === NONE_VALUE ? undefined : value)}
+                >
+                  <SelectTrigger id="create-plan">
+                    <SelectValue
+                      placeholder={planSlugOptions.length ? "Select plan slug" : "No public plans"}
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NONE_VALUE}>No plan</SelectItem>
+                    {planSlugOptions.map((slug) => (
+                      <SelectItem key={slug} value={slug}>
+                        {slug}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          />
+          <Controller
+            control={form.control}
+            name="subscriptionStatus"
+            render={({ field }) => (
+              <div className="grid gap-2">
+                <Label htmlFor="create-subscription-status">Subscription status</Label>
+                <Select
+                  disabled={isSubmitting}
+                  value={field.value ?? NONE_VALUE}
+                  onValueChange={(value) => field.onChange(value === NONE_VALUE ? undefined : value)}
+                >
+                  <SelectTrigger id="create-subscription-status">
+                    <SelectValue placeholder="Select subscription status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NONE_VALUE}>No status</SelectItem>
+                    {SUBSCRIPTION_STATUS_OPTIONS.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {status}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          />
+        </form>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full sm:w-auto"
+            onClick={() => onOpenChange?.(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" form="create-user-form" className="w-full sm:w-auto" disabled={isSubmitting}>
+            {isSubmitting ? "Creating…" : "Create user"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/features/admin/user-table.js
+++ b/src/components/features/admin/user-table.js
@@ -1,20 +1,37 @@
 // File: src/components/features/admin/user-table.js
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const toSearchable = (value) => {
+  if (value == null) return "";
+  return String(value).toLowerCase();
+};
 
 // Table of users with quick search and navigation to profiles.
 export default function UserTable({ users = [], onViewProfile }) {
   const [search, setSearch] = useState("");
 
   const filteredUsers = useMemo(() => {
-    const term = search.toLowerCase();
-    return users.filter((user) =>
-      [user.username, user.email, user.plan].some((value) => value.toLowerCase().includes(term))
-    );
+    const normalizedUsers = Array.isArray(users) ? users : [];
+    const term = search.trim().toLowerCase();
+    if (!term) return normalizedUsers;
+    return normalizedUsers.filter((user) => {
+      const fields = [
+        user.username,
+        user.email,
+        user.fullName,
+        user.planName,
+        user.plan,
+        user.statusLabel,
+        user.role,
+      ];
+      return fields.some((value) => toSearchable(value).includes(term));
+    });
   }, [users, search]);
 
   return (
@@ -42,12 +59,38 @@ export default function UserTable({ users = [], onViewProfile }) {
           </TableHeader>
           <TableBody>
             {filteredUsers.map((user) => (
-              <TableRow key={user.id}>
-                <TableCell className="font-medium">{user.username}</TableCell>
-                <TableCell>{user.email}</TableCell>
-                <TableCell>{user.plan}</TableCell>
-                <TableCell>{user.status}</TableCell>
-                <TableCell>{user.registeredAt}</TableCell>
+              <TableRow key={user.id ?? user.username ?? user.email}>
+                <TableCell className="font-medium">
+                  <div>{user.username || "—"}</div>
+                  {user.fullName ? (
+                    <div className="text-xs text-muted-foreground">{user.fullName}</div>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  {user.email || "—"}
+                  {user.lastLoginAtLabel ? (
+                    <div className="text-xs text-muted-foreground">Last seen {user.lastLoginAtLabel}</div>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  <div>{user.planName || user.plan || "—"}</div>
+                  {user.subscriptionStatusLabel ? (
+                    <div className="text-xs text-muted-foreground">{user.subscriptionStatusLabel}</div>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  {user.statusLabel ? (
+                    <Badge variant={user.isActive ? "default" : "secondary"}>{user.statusLabel}</Badge>
+                  ) : (
+                    "—"
+                  )}
+                </TableCell>
+                <TableCell>
+                  {user.registeredAtLabel || user.registeredAt || "—"}
+                  {user.isActiveLabel ? (
+                    <div className="text-xs text-muted-foreground">{user.isActiveLabel}</div>
+                  ) : null}
+                </TableCell>
                 <TableCell className="text-right">
                   <Button size="sm" variant="outline" onClick={() => onViewProfile?.(user)}>
                     View Profile

--- a/src/lib/mock-data.js
+++ b/src/lib/mock-data.js
@@ -141,33 +141,6 @@ const adminPayments = [
   { id: "pay-03", user: "strategist", amount: 29, method: "Card", status: "Approved", submittedAt: "2025-01-07" },
 ];
 
-const adminUsers = [
-  {
-    id: "68170801c901776f5f01d330",
-    username: "kobirhumayun",
-    email: "kobirhumayun@gmail.com",
-    plan: "Professional",
-    registeredAt: "2024-03-18",
-    status: "Active",
-  },
-  {
-    id: "681707f8c901776f5f01d32d",
-    username: "growthlead",
-    email: "growthlead@example.com",
-    plan: "Business",
-    registeredAt: "2024-07-22",
-    status: "Invited",
-  },
-  {
-    id: "68170c9ac901776f5f01d37b",
-    username: "analyticspro",
-    email: "analytics@example.com",
-    plan: "Enterprise",
-    registeredAt: "2024-10-05",
-    status: "Active",
-  },
-];
-
 export async function fetchDashboardSummary() {
   await delay();
   return dashboardSummary;
@@ -225,22 +198,3 @@ export async function fetchAdminPayments() {
   return adminPayments;
 }
 
-export async function fetchAdminUsers() {
-  await delay();
-  return adminUsers;
-}
-
-export async function fetchAdminUserProfile(userId) {
-  await delay();
-  return (
-    adminUsers.find((user) => user.id === userId) || {
-      id: userId,
-      username: "unknown",
-      email: "unknown@example.com",
-      plan: "Free",
-      registeredAt: "2024-01-01",
-      status: "Unknown",
-      orders: [],
-    }
-  );
-}

--- a/src/lib/queries/admin-users.js
+++ b/src/lib/queries/admin-users.js
@@ -1,0 +1,302 @@
+// lib/queries/admin-users.js
+import { apiJSON } from "@/lib/api";
+import { qk } from "@/lib/query-keys";
+
+const ADMIN_USERS_ENDPOINT = "/api/admin/users";
+
+const ensureArray = (value) => {
+  if (Array.isArray(value)) return value;
+  if (Array.isArray(value?.items)) return value.items;
+  if (Array.isArray(value?.data)) return value.data;
+  if (Array.isArray(value?.results)) return value.results;
+  if (Array.isArray(value?.payload)) return value.payload;
+  if (Array.isArray(value?.rows)) return value.rows;
+  if (Array.isArray(value?.users)) return value.users;
+  if (value?.items) return ensureArray(value.items);
+  if (value?.data) return ensureArray(value.data);
+  if (value?.results) return ensureArray(value.results);
+  return [];
+};
+
+const extractId = (value) => {
+  if (!value) return null;
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  if (typeof value === "object") {
+    if (value.$oid) return extractId(value.$oid);
+    if (value._id) return extractId(value._id);
+    if (value.id) return extractId(value.id);
+  }
+  return null;
+};
+
+const toStringSafe = (value) => {
+  if (value == null) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return null;
+};
+
+const normalizeBoolean = (value) => {
+  if (value === true || value === false) return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "active", "enabled"].includes(normalized)) return true;
+    if (["false", "0", "no", "inactive", "disabled"].includes(normalized)) return false;
+  }
+  return null;
+};
+
+const extractDate = (value) => {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  if (typeof value === "object") {
+    if (value.$date) return extractDate(value.$date);
+  }
+  return null;
+};
+
+const formatDate = (value) => {
+  const iso = extractDate(value);
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { dateStyle: "medium" });
+  } catch {
+    return iso;
+  }
+};
+
+const formatDateTime = (value) => {
+  const iso = extractDate(value);
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+  } catch {
+    return iso;
+  }
+};
+
+const formatStatusLabel = (status) => {
+  const value = toStringSafe(status)?.trim();
+  if (!value) return null;
+  return value
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+};
+
+export const normalizeAdminUser = (user) => {
+  if (!user || typeof user !== "object") return null;
+
+  const raw = user.raw && typeof user.raw === "object" ? user.raw : user;
+  const merged = { ...raw, ...user };
+
+  const id = extractId(merged.id ?? merged._id);
+  const username = toStringSafe(merged.username)?.trim() || null;
+  const email = toStringSafe(merged.email)?.trim() || null;
+  const firstName = toStringSafe(merged.firstName)?.trim() || null;
+  const lastName = toStringSafe(merged.lastName)?.trim() || null;
+  const fullName = [firstName, lastName].filter(Boolean).join(" ") || null;
+
+  const planId = extractId(merged.planId) || toStringSafe(merged.planId);
+  const planName =
+    toStringSafe(merged.plan?.name) ||
+    toStringSafe(merged.planName) ||
+    toStringSafe(merged.plan) ||
+    (typeof merged.planId === "object" ? toStringSafe(merged.planId?.name) : null);
+  const planSlug =
+    toStringSafe(merged.plan?.slug) ||
+    toStringSafe(merged.planSlug) ||
+    (typeof merged.planId === "object" ? toStringSafe(merged.planId?.slug) : null) ||
+    (typeof planId === "string" && planId.includes("-") ? planId : null);
+
+  const subscriptionStatus = toStringSafe(merged.subscriptionStatus)?.trim() || null;
+  const subscriptionStatusLabel = formatStatusLabel(subscriptionStatus);
+  const subscriptionStartDate = extractDate(merged.subscriptionStartDate);
+  const subscriptionEndDate = extractDate(merged.subscriptionEndDate);
+  const trialEndsAt = extractDate(merged.trialEndsAt);
+
+  const role = toStringSafe(merged.role)?.trim() || null;
+  const isActive = normalizeBoolean(merged.isActive ?? merged.metadata?.isActive ?? merged.raw?.isActive);
+
+  const statusCode =
+    toStringSafe(merged.statusCode ?? merged.metadata?.accountStatus ?? merged.status)?.trim() ||
+    (isActive === false ? "inactive" : isActive === true ? "active" : null);
+  const statusLabel = formatStatusLabel(statusCode) || formatStatusLabel(merged.status);
+
+  const registeredAt = extractDate(merged.registeredAt ?? merged.createdAt);
+  const lastLoginAt = extractDate(merged.lastLoginAt ?? merged.updatedAt);
+
+  const profilePictureUrl = toStringSafe(merged.profilePictureUrl ?? merged.avatarUrl) || null;
+
+  return {
+    id,
+    username,
+    email,
+    firstName,
+    lastName,
+    fullName,
+    planId,
+    planSlug,
+    planName,
+    plan: planName,
+    subscriptionStatus,
+    subscriptionStatusLabel,
+    subscriptionStartDate,
+    subscriptionStartDateLabel: formatDate(subscriptionStartDate),
+    subscriptionEndDate,
+    subscriptionEndDateLabel: formatDate(subscriptionEndDate),
+    trialEndsAt,
+    trialEndsAtLabel: formatDate(trialEndsAt),
+    role,
+    isActive: isActive ?? false,
+    isActiveLabel: isActive == null ? null : isActive ? "Active" : "Inactive",
+    statusCode,
+    status: statusLabel,
+    statusLabel,
+    registeredAt,
+    registeredAtLabel: formatDate(registeredAt),
+    registeredAtDateTimeLabel: formatDateTime(registeredAt),
+    lastLoginAt,
+    lastLoginAtLabel: formatDateTime(lastLoginAt),
+    profilePictureUrl,
+    raw,
+  };
+};
+
+export const mergeAdminUser = (previous, patch = {}) => {
+  if (!previous) {
+    const raw = patch && typeof patch === "object" && !Array.isArray(patch) ? patch : {};
+    return normalizeAdminUser({ ...raw, raw });
+  }
+  const prevRaw = previous.raw && typeof previous.raw === "object" ? previous.raw : previous;
+  const mergedRaw = { ...prevRaw, ...patch };
+  if (previous.id && !mergedRaw.id) mergedRaw.id = previous.id;
+  if (previous.username && !mergedRaw.username) mergedRaw.username = previous.username;
+  if (previous.email && !mergedRaw.email) mergedRaw.email = previous.email;
+  return normalizeAdminUser({ ...mergedRaw, raw: mergedRaw });
+};
+
+const sanitizeListFilters = (filters = {}) => {
+  if (!filters || typeof filters !== "object") return {};
+  const result = {};
+  if (typeof filters.search === "string" && filters.search.trim()) {
+    result.search = filters.search.trim();
+  }
+  if (typeof filters.status === "string" && filters.status.trim() && filters.status.trim().toLowerCase() !== "all") {
+    result.status = filters.status.trim();
+  }
+  if (filters.page != null) {
+    const page = Number(filters.page);
+    if (Number.isFinite(page) && page > 0) {
+      result.page = page;
+    }
+  }
+  if (filters.limit != null) {
+    const limit = Number(filters.limit);
+    if (Number.isFinite(limit) && limit > 0) {
+      result.limit = limit;
+    }
+  }
+  return result;
+};
+
+const buildQueryString = (filters = {}) => {
+  const params = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value == null || value === "") return;
+    params.set(key, String(value));
+  });
+  const query = params.toString();
+  return query ? `?${query}` : "";
+};
+
+const normalizePagination = (pagination) => {
+  if (!pagination || typeof pagination !== "object") return null;
+  return {
+    currentPage: pagination.currentPage ?? null,
+    totalPages: pagination.totalPages ?? null,
+    totalItems: pagination.totalItems ?? null,
+    itemsPerPage: pagination.itemsPerPage ?? null,
+  };
+};
+
+export const adminUsersOptions = (filters = {}) => {
+  const sanitized = sanitizeListFilters(filters);
+  const query = buildQueryString(sanitized);
+  const keyArg = Object.keys(sanitized).length ? sanitized : undefined;
+
+  return {
+    queryKey: qk.admin.users(keyArg),
+    queryFn: async ({ signal }) => {
+      const response = await apiJSON(`${ADMIN_USERS_ENDPOINT}${query}`, { signal });
+      const rawItems = ensureArray(response?.items ?? response?.data ?? response);
+      const items = rawItems.map((item) => normalizeAdminUser({ ...item, raw: item })).filter(Boolean);
+      const pagination = normalizePagination(response?.pagination);
+      const statusSet = new Set();
+      (response?.availableStatuses ?? []).forEach((status) => {
+        const str = toStringSafe(status)?.trim();
+        if (str) statusSet.add(str);
+      });
+      items.forEach((item) => {
+        if (item?.statusCode) statusSet.add(item.statusCode);
+      });
+      return {
+        items,
+        pagination,
+        availableStatuses: Array.from(statusSet),
+        raw: response,
+      };
+    },
+    staleTime: 30_000,
+  };
+};
+
+export const adminUserProfileOptions = (userId) => ({
+  queryKey: qk.admin.userProfile(userId),
+  queryFn: async ({ signal }) => {
+    if (!userId) throw new Error("User ID is required");
+    const response = await apiJSON(`${ADMIN_USERS_ENDPOINT}/${userId}`, { signal });
+    return normalizeAdminUser({ ...response, raw: response });
+  },
+  enabled: Boolean(userId),
+  staleTime: 30_000,
+});
+
+export const updateAdminUser = ({ userId, updates }) => {
+  if (!userId) throw new Error("User ID is required for update");
+  if (!updates || typeof updates !== "object") throw new Error("Update payload is required");
+  return apiJSON(`${ADMIN_USERS_ENDPOINT}/${userId}`, {
+    method: "PATCH",
+    body: updates,
+  });
+};
+
+export const updateAdminUserStatus = ({ userId, status }) => {
+  if (!userId) throw new Error("User ID is required for status update");
+  if (!status) throw new Error("Status value is required");
+  return apiJSON(`${ADMIN_USERS_ENDPOINT}/${userId}/status`, {
+    method: "PATCH",
+    body: { status },
+  });
+};
+
+export const resetAdminUserPassword = ({ userId, redirectUri }) => {
+  if (!userId) throw new Error("User ID is required to reset password");
+  const body = {};
+  if (redirectUri) body.redirectUri = redirectUri;
+  return apiJSON(`${ADMIN_USERS_ENDPOINT}/${userId}/reset-password`, {
+    method: "POST",
+    body,
+  });
+};
+
+export const formatAdminUserStatus = formatStatusLabel;
+export const formatAdminUserDate = formatDate;
+export const formatAdminUserDateTime = formatDateTime;

--- a/src/lib/queries/admin-users.js
+++ b/src/lib/queries/admin-users.js
@@ -278,6 +278,16 @@ export const updateAdminUser = ({ userId, updates }) => {
   });
 };
 
+export const createAdminUser = (payload) => {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Create payload is required");
+  }
+  return apiJSON(ADMIN_USERS_ENDPOINT, {
+    method: "POST",
+    body: payload,
+  });
+};
+
 export const updateAdminUserStatus = ({ userId, status }) => {
   if (!userId) throw new Error("User ID is required for status update");
   if (!status) throw new Error("Status value is required");

--- a/src/lib/queries/admin-users.js
+++ b/src/lib/queries/admin-users.js
@@ -289,11 +289,10 @@ export const updateAdminUserStatus = ({ userId, status }) => {
 
 export const resetAdminUserPassword = ({ userId, redirectUri }) => {
   if (!userId) throw new Error("User ID is required to reset password");
-  const body = {};
-  if (redirectUri) body.redirectUri = redirectUri;
+  const payload = redirectUri ? { redirectUri } : undefined;
   return apiJSON(`${ADMIN_USERS_ENDPOINT}/${userId}/reset-password`, {
     method: "POST",
-    body,
+    ...(payload ? { body: payload } : {}),
   });
 };
 

--- a/src/lib/query-keys.js
+++ b/src/lib/query-keys.js
@@ -45,7 +45,29 @@ export const qk = {
       }
       return ["admin", "payments", filters];
     },
-    users: () => ["admin", "users"],
+    users: (filters) => {
+      if (!filters || (typeof filters === "object" && Object.keys(filters).length === 0)) {
+        return ["admin", "users"];
+      }
+      if (typeof filters === "string") {
+        return ["admin", "users", filters];
+      }
+      if (typeof filters === "object") {
+        const normalized = Object.keys(filters)
+          .sort()
+          .reduce((acc, key) => {
+            const value = filters[key];
+            if (value === undefined) return acc;
+            acc[key] = value;
+            return acc;
+          }, {});
+        if (Object.keys(normalized).length === 0) {
+          return ["admin", "users"];
+        }
+        return ["admin", "users", normalized];
+      }
+      return ["admin", "users", filters];
+    },
     userProfile: (id) => ["admin", "users", String(id)],
   },
 };


### PR DESCRIPTION
## Summary
- add admin user query utilities that normalize API responses and expose query/mutation helpers
- rework admin user list and profile screens to consume live data with optimistic mutations and status management
- update the admin dashboard and remove obsolete mock data so shared queries stay in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68de44827508832e833339ee88b4e12f